### PR TITLE
Fix Prisma CLI version mismatch during generate

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,7 +27,8 @@
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-import": "2.29.1",
         "jest": "29.7.0",
-        "prettier": "3.1.1"
+        "prettier": "3.1.1",
+        "prisma": "5.7.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1260,6 +1261,56 @@
         "prisma": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.7.0.tgz",
+      "integrity": "sha512-tZ+MOjWlVvz1kOEhNYMa4QUGURY+kgOUBqLHYIV8jmCsMuvA1tWcn7qtIMLzYWCbDcQT4ZS8xDgK0R2gl6/0wA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.7.0.tgz",
+      "integrity": "sha512-TkOMgMm60n5YgEKPn9erIvFX2/QuWnl3GBo6yTRyZKk5O5KQertXiNnrYgSLy0SpsKmhovEPQb+D4l0SzyE7XA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.7.0",
+        "@prisma/engines-version": "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9",
+        "@prisma/fetch-engine": "5.7.0",
+        "@prisma/get-platform": "5.7.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9.tgz",
+      "integrity": "sha512-V6tgRVi62jRwTm0Hglky3Scwjr/AKFBFtS+MdbsBr7UOuiu1TKLPc6xfPiyEN1+bYqjEtjxwGsHgahcJsd1rNg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.7.0.tgz",
+      "integrity": "sha512-zIn/qmO+N/3FYe7/L9o+yZseIU8ivh4NdPKSkQRIHfg2QVTVMnbhGoTcecbxfVubeTp+DjcbjS0H9fCuM4W04w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.7.0",
+        "@prisma/engines-version": "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9",
+        "@prisma/get-platform": "5.7.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.7.0.tgz",
+      "integrity": "sha512-ZeV/Op4bZsWXuw5Tg05WwRI8BlKiRFhsixPcAM+5BKYSiUZiMKIi713tfT3drBq8+T0E1arNZgYSA9QYcglWNA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.7.0"
       }
     },
     "node_modules/@scarf/scarf": {
@@ -6570,6 +6621,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.7.0.tgz",
+      "integrity": "sha512-0rcfXO2ErmGAtxnuTNHQT9ztL0zZheQjOI/VNJzdq87C3TlGPQtMqtM+KCwU6XtmkoEr7vbCQqA7HF9IY0ST+Q==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.7.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
       }
     },
     "node_modules/prompts": {

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-import": "2.29.1",
     "jest": "29.7.0",
-    "prettier": "3.1.1"
+    "prettier": "3.1.1",
+    "prisma": "5.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add the Prisma CLI as a dev dependency to ensure it matches the installed client
- update the lockfile so Docker uses the pinned Prisma engine during `prisma generate`

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68e39f9ab15c83338964b64542e095cc