### PR TITLE
fix: install openssl compatibility for prisma

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,10 @@
 FROM node:18-alpine
+
+# Prisma requires OpenSSL to be available when generating the client.
+# The alpine variant does not ship the compatibility package by default,
+# so we install it explicitly to avoid runtime errors when the schema
+# engine boots up.
+RUN apk add --no-cache openssl1.1-compat
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install


### PR DESCRIPTION
## Summary
- install the openssl1.1 compatibility package in the server Docker image so Prisma can detect libssl and run the schema engine reliably

## Testing
- not run (not requested)
