### PR TITLE
Fix server Dockerfile OpenSSL dependency

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,10 +1,9 @@
 FROM node:18-alpine
 
 # Prisma requires OpenSSL to be available when generating the client.
-# The alpine variant does not ship the compatibility package by default,
-# so we install it explicitly to avoid runtime errors when the schema
-# engine boots up.
-RUN apk add --no-cache openssl1.1-compat
+# The alpine variant does not ship it by default, so we install it
+# explicitly to avoid runtime errors when the schema engine boots up.
+RUN apk add --no-cache openssl
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install


### PR DESCRIPTION
## Summary
- replace the unavailable `openssl1.1-compat` package with the standard `openssl` package for the server Docker image
- update the accompanying comment to reflect the updated dependency

## Testing
- not run (docker build)

