### PR TITLE
Add initial Prisma migration and unique product constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Added initial Prisma migration to provision PostgreSQL tables during deployment.
+- Marked product names as unique to align with seed upserts.
+
 ## 1.0.0 - 2024-05-07
 - Initial release of Hemar Mobile Store platform.
 - Added Express API with Prisma + PostgreSQL and Mongoose + MongoDB integration.

--- a/DB-SCHEMA.md
+++ b/DB-SCHEMA.md
@@ -17,7 +17,7 @@
 | Column | Type | Notes |
 | --- | --- | --- |
 | id | Int | Primary key |
-| name | String |  |
+| name | String | Unique |
 | description | String |  |
 | price | Decimal(10,2) |  |
 | imageUrl | String |  |

--- a/server/prisma/migration_lock.toml
+++ b/server/prisma/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/server/prisma/migrations/20231006113013_init/migration.sql
+++ b/server/prisma/migrations/20231006113013_init/migration.sql
@@ -1,0 +1,88 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'CUSTOMER');
+
+-- CreateEnum
+CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'CONFIRMED', 'SHIPPED', 'DELIVERED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" SERIAL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'CUSTOMER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" SERIAL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "price" NUMERIC(10, 2) NOT NULL,
+    "imageUrl" TEXT NOT NULL,
+    "brand" TEXT NOT NULL,
+    "stock" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Order" (
+    "id" SERIAL PRIMARY KEY,
+    "userId" INTEGER NOT NULL,
+    "total" NUMERIC(10, 2) NOT NULL,
+    "status" "OrderStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "shippingPhone" TEXT NOT NULL,
+    "shippingName" TEXT NOT NULL,
+    "shippingAddr" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "OrderItem" (
+    "id" SERIAL PRIMARY KEY,
+    "orderId" INTEGER NOT NULL,
+    "productId" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "price" NUMERIC(10, 2) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "Product_name_key" ON "Product"("name");
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Create trigger to update updatedAt columns
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW."updatedAt" = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_user_updated_at
+BEFORE UPDATE ON "User"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_product_updated_at
+BEFORE UPDATE ON "Product"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_order_updated_at
+BEFORE UPDATE ON "Order"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -25,7 +25,7 @@ enum Role {
 
 model Product {
   id          Int         @id @default(autoincrement())
-  name        String
+  name        String      @unique
   description String
   price       Decimal     @db.Decimal(10, 2)
   imageUrl    String


### PR DESCRIPTION
## Summary
- add the first Prisma migration so the PostgreSQL tables are created before seeding
- mark the product name as unique and mirror the change in the docs
- record the database bootstrap fix in the changelog

## Testing
- npm --prefix server run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3a8f744dc8333944ed8e12d56191d