### PR TITLE
Add admin console for managing products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Added initial Prisma migration to provision PostgreSQL tables during deployment.
 - Marked product names as unique to align with seed upserts.
+- Delivered admin console UI for managing catalog entries and documented seeded admin credentials.
 
 ## 1.0.0 - 2024-05-07
 - Initial release of Hemar Mobile Store platform.

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -5,3 +5,4 @@
 | MainLayout | App bar navigation shell shared across pages | `client/src/layouts/MainLayout.jsx` |
 | AuthContext | Provides authentication state and helpers | `client/src/features/auth/AuthContext.jsx` |
 | CartContext | Manages cart state and checkout actions | `client/src/features/cart/CartContext.jsx` |
+| AdminProductForm | Controlled form for creating products within the admin console | `client/src/features/products/components/AdminProductForm.jsx` |

--- a/DB-SCHEMA.md
+++ b/DB-SCHEMA.md
@@ -58,3 +58,7 @@
 | metadata | Object | Optional structured context |
 | createdAt | Date | Timestamp |
 | updatedAt | Date | Timestamp |
+
+## Seed Data Notes
+- The database seed ensures an `ADMIN` role user is created using the `ADMIN_EMAIL`/`ADMIN_PASSWORD` environment variables
+  (defaults: `admin@hemar.test` / `SuperSecure123!`).

--- a/PAGES.md
+++ b/PAGES.md
@@ -7,3 +7,4 @@
 | Register | Create a new customer account | `client/src/features/auth/RegisterPage.jsx` |
 | Cart | Manage cart items and submit checkout form | `client/src/features/cart/CartPage.jsx` |
 | Orders | View authenticated order history | `client/src/features/orders/OrdersPage.jsx` |
+| Admin Console | Add new products and review inventory (admin only) | `client/src/features/products/AdminProductsPage.jsx` |

--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,15 @@ cp client/.env.example client/.env
 ```
 Update the environment variables as required before starting the stack.
 
+### Admin Access
+The seed process provisions an administrator account using the credentials defined in `server/.env` (defaults shown below):
+
+- **Admin email:** `admin@hemar.test`
+- **Admin password:** `SuperSecure123!`
+
+Log in with these credentials at `http://localhost:3000/login` to reach the admin console located at `http://localhost:3000/admin/products`.
+From there you can add new products and review the catalog inventory. Remember to change the default password in production.
+
 ### NPM Scripts
 Each package exposes helpful scripts:
 
@@ -44,6 +53,7 @@ Each package exposes helpful scripts:
 ## Features
 - Customer registration and login with JWT-based authentication.
 - Admin-protected CRUD APIs for managing phone catalog entries.
+- React-based admin console for adding products and reviewing inventory.
 - Shopping cart and checkout flow that creates orders and updates stock.
 - Order history for authenticated customers.
 - Mongo-backed activity log capturing catalog and order events.

--- a/ROUTES.md
+++ b/ROUTES.md
@@ -6,6 +6,7 @@
 - `/register` – Customer registration page.
 - `/cart` – Shopping cart & checkout form.
 - `/orders` – Authenticated order history.
+- `/admin/products` – Admin console for managing the catalog (admin only).
 
 ## Backend API
 - `/api/auth/*` – Authentication endpoints.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,11 +5,14 @@ import { routes } from './routes.js';
 import { MainLayout } from './layouts/MainLayout.jsx';
 import { useAuth } from './features/auth/AuthContext.jsx';
 
-const RouteGuard = ({ requiresAuth, element }) => {
+const RouteGuard = ({ requiresAuth, requiresRole, element }) => {
   const { user } = useAuth();
   const location = useLocation();
   if (requiresAuth && !user) {
     return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+  if (requiresRole && (!user || user.role !== requiresRole)) {
+    return <Navigate to="/" replace />;
   }
   return element;
 };
@@ -24,11 +27,17 @@ const App = () => (
       )}
     >
       <Routes>
-        {routes.map(({ path, Component, requiresAuth }) => (
+        {routes.map(({ path, Component, requiresAuth, requiresRole }) => (
           <Route
             key={path}
             path={path}
-            element={<RouteGuard requiresAuth={requiresAuth} element={<Component />} />}
+            element={
+              <RouteGuard
+                requiresAuth={requiresAuth}
+                requiresRole={requiresRole}
+                element={<Component />}
+              />
+            }
           />
         ))}
       </Routes>

--- a/client/src/features/products/AdminProductsPage.jsx
+++ b/client/src/features/products/AdminProductsPage.jsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Chip,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded';
+import Inventory2RoundedIcon from '@mui/icons-material/Inventory2Rounded';
+import { api } from '../../lib/api.js';
+import { AdminProductForm } from './components/AdminProductForm.jsx';
+
+const formatCurrency = (value) => {
+  const amount = Number.isFinite(value) ? value : 0;
+  return `$${amount.toFixed(2)}`;
+};
+
+/**
+ * Administrative console that enables catalog management.
+ * @returns {JSX.Element}
+ */
+const AdminProductsPage = () => {
+  const [products, setProducts] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [fetchError, setFetchError] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+  const [submitSuccess, setSubmitSuccess] = useState(null);
+
+  const loadProducts = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await api.get('/products');
+      setProducts(response.data.products);
+      setFetchError(null);
+    } catch (error) {
+      setFetchError('Failed to load products. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadProducts();
+  }, [loadProducts]);
+
+  const handleCreate = useCallback(
+    async (payload) => {
+      setIsSubmitting(true);
+      setSubmitError(null);
+      setSubmitSuccess(null);
+      try {
+        await api.post('/products', payload);
+        setSubmitSuccess('Product added successfully.');
+        await loadProducts();
+        return true;
+      } catch (error) {
+        const message = error?.response?.data?.message || 'Unable to create product. Check the fields and try again.';
+        setSubmitError(message);
+        return false;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [loadProducts]
+  );
+
+  const productCount = useMemo(() => products.length, [products]);
+
+  return (
+    <Stack spacing={4}>
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 3, md: 4 },
+          background: 'linear-gradient(135deg, rgba(14,116,144,0.08) 0%, rgba(30,64,175,0.12) 100%)',
+        }}
+      >
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={3} alignItems={{ xs: 'flex-start', md: 'center' }}>
+          <Stack direction="row" spacing={2} alignItems="center" flex={1}>
+            <Avatar sx={{ bgcolor: 'primary.main', width: 56, height: 56 }}>
+              <Inventory2RoundedIcon />
+            </Avatar>
+            <Box>
+              <Typography variant="h4">Admin Console</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Manage the Hemar catalog, add upcoming launches, and review inventory in real time.
+              </Typography>
+            </Box>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Chip color="primary" label={`${productCount} products`} />
+            <Tooltip title="Refresh product list">
+              <span>
+                <IconButton onClick={loadProducts} disabled={isLoading}>
+                  <RefreshRoundedIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </Stack>
+        </Stack>
+      </Paper>
+
+      {submitSuccess && <Alert severity="success">{submitSuccess}</Alert>}
+      {submitError && <Alert severity="error">{submitError}</Alert>}
+
+      <AdminProductForm onSubmit={handleCreate} isSubmitting={isSubmitting} />
+
+      <Stack spacing={2} component={Paper} elevation={1} sx={{ p: 3 }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6">Catalog overview</Typography>
+          {isLoading && <Typography variant="caption">Refreshing…</Typography>}
+        </Stack>
+        {fetchError ? (
+          <Alert severity="error">{fetchError}</Alert>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Brand</TableCell>
+                  <TableCell>Price</TableCell>
+                  <TableCell align="right">Stock</TableCell>
+                  <TableCell>Updated</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {products.map((product) => (
+                  <TableRow key={product.id} hover>
+                    <TableCell>
+                      <Stack spacing={0.5}>
+                        <Typography fontWeight={600}>{product.name}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {product.description
+                            ? `${product.description.slice(0, 96)}${
+                                product.description.length > 96 ? '…' : ''
+                              }`
+                            : 'No description provided'}
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>{product.brand}</TableCell>
+                    <TableCell>{formatCurrency(Number(product.price ?? 0))}</TableCell>
+                    <TableCell align="right">{product.stock}</TableCell>
+                    <TableCell>
+                      {new Date(product.updatedAt).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!products.length && !isLoading && (
+                  <TableRow>
+                    <TableCell colSpan={5}>
+                      <Stack alignItems="center" spacing={1} sx={{ py: 4 }}>
+                        <Typography variant="subtitle1">No products yet</Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          Use the form above to add your first catalog item.
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+        <Divider sx={{ borderStyle: 'dashed' }} />
+        <Typography variant="caption" color="text.secondary">
+          All operations are logged in the activity feed for audit purposes.
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default AdminProductsPage;

--- a/client/src/features/products/README.md
+++ b/client/src/features/products/README.md
@@ -1,0 +1,4 @@
+# Products Feature
+
+Provides the administrator console for managing catalog entries. The page loads the current `/api/products` collection, allows
+privileged users to create new items, and surfaces a compact inventory overview table.

--- a/client/src/features/products/components/AdminProductForm.jsx
+++ b/client/src/features/products/components/AdminProductForm.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid,
+  TextField,
+} from '@mui/material';
+import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRounded';
+
+const emptyForm = {
+  name: '',
+  description: '',
+  price: '',
+  imageUrl: '',
+  brand: '',
+  stock: '',
+};
+
+/**
+ * Renders the product creation form for administrators.
+ * @param {{
+ *   onSubmit: (payload: {
+ *     name: string;
+ *     description: string;
+ *     price: number;
+ *     imageUrl: string;
+ *     brand: string;
+ *     stock: number;
+ *   }) => Promise<boolean>;
+ *   isSubmitting: boolean;
+ * }} props
+ */
+export const AdminProductForm = ({ onSubmit, isSubmitting }) => {
+  const [form, setForm] = useState(emptyForm);
+
+  const handleChange = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const payload = {
+      name: form.name.trim(),
+      description: form.description.trim(),
+      imageUrl: form.imageUrl.trim(),
+      brand: form.brand.trim(),
+      price: Number.parseFloat(form.price),
+      stock: Number.parseInt(form.stock, 10),
+    };
+    if (Number.isNaN(payload.price) || Number.isNaN(payload.stock)) {
+      return;
+    }
+    const created = await onSubmit(payload);
+    if (created) {
+      setForm(emptyForm);
+    }
+  };
+
+  return (
+    <Card component="section" elevation={2}>
+      <CardHeader
+        title="Add a new product"
+        subheader="Provide the core catalog details. Stock updates immediately for the storefront."
+      />
+      <CardContent>
+        <Box component="form" onSubmit={handleSubmit}>
+          <Grid container spacing={2.5}>
+            <Grid item xs={12} md={6}>
+              <TextField
+                required
+                fullWidth
+                label="Product name"
+                value={form.name}
+                onChange={handleChange('name')}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField
+                required
+                fullWidth
+                label="Brand"
+                value={form.brand}
+                onChange={handleChange('brand')}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField
+                required
+                fullWidth
+                type="number"
+                inputProps={{ step: '0.01', min: '0' }}
+                label="Price (USD)"
+                value={form.price}
+                onChange={handleChange('price')}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField
+                required
+                fullWidth
+                type="number"
+                inputProps={{ min: '0' }}
+                label="Stock"
+                value={form.stock}
+                onChange={handleChange('stock')}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                required
+                fullWidth
+                multiline
+                minRows={3}
+                label="Description"
+                value={form.description}
+                onChange={handleChange('description')}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                required
+                fullWidth
+                label="Image URL"
+                value={form.imageUrl}
+                onChange={handleChange('imageUrl')}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <Button
+                type="submit"
+                variant="contained"
+                size="large"
+                startIcon={<AddCircleOutlineRoundedIcon />}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Saving…' : 'Create product'}
+              </Button>
+            </Grid>
+          </Grid>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -22,4 +22,10 @@ export const routes = [
     Component: lazy(() => import('./features/orders/OrdersPage.jsx')),
     requiresAuth: true,
   },
+  {
+    path: '/admin/products',
+    Component: lazy(() => import('./features/products/AdminProductsPage.jsx')),
+    requiresAuth: true,
+    requiresRole: 'ADMIN',
+  },
 ];

--- a/docs/client/admin-console.md
+++ b/docs/client/admin-console.md
@@ -1,0 +1,9 @@
+# Admin Console
+
+- **Route:** `/admin/products`
+- **Purpose:** Allow administrators to add catalog entries and monitor inventory levels.
+- **Data sources:**
+  - `GET /api/products` for listing existing items.
+  - `POST /api/products` for creating new products.
+- **Access control:** Route guard enforces authenticated `ADMIN` role users only.
+- **UI notes:** Uses `AdminProductForm` for submissions and a Material UI table for quick inventory insight.

--- a/server/src/modules/products/README.md
+++ b/server/src/modules/products/README.md
@@ -1,3 +1,4 @@
 # Products Module
 
 Provides CRUD APIs for managing mobile phone catalog entries and exposing them to the storefront.
+The admin console uses the same endpoints to create new products and review inventory.


### PR DESCRIPTION
## Summary
- add a React admin console page for managing products and guard it behind the admin role
- update navigation, routing, and documentation to surface the admin console and seeded credentials

## Testing
- npm run lint (client)
