### PR TITLE
Add admin product editing workflow

### DIFF
--- a/client/src/features/products/components/AdminProductEditDialog.jsx
+++ b/client/src/features/products/components/AdminProductEditDialog.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+} from '@mui/material';
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
+import { ProductFormFields } from './ProductFormFields.jsx';
+import { buildProductPayload, createEmptyProductForm, mapProductToFormValues } from './formUtils.js';
+
+/**
+ * Modal dialog used to edit an existing product.
+ * @param {{
+ *   open: boolean;
+ *   product: import('../../../shared/types/products.js').Product | null;
+ *   onClose: () => void;
+ *   onSubmit: (payload: ReturnType<typeof buildProductPayload>) => Promise<boolean>;
+ *   isSubmitting: boolean;
+ * }} props
+ */
+export const AdminProductEditDialog = ({ open, product, onClose, onSubmit, isSubmitting }) => {
+  const [form, setForm] = useState(createEmptyProductForm());
+
+  useEffect(() => {
+    if (open && product) {
+      setForm(mapProductToFormValues(product));
+    } else {
+      setForm(createEmptyProductForm());
+    }
+  }, [open, product]);
+
+  const handleChange = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const payload = buildProductPayload(form);
+    if (!payload) {
+      return;
+    }
+    const updated = await onSubmit(payload);
+    if (updated) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Edit product</DialogTitle>
+      <DialogContent>
+        <Box component="form" id="admin-product-edit-form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
+          <Grid container spacing={2.5}>
+            <ProductFormFields form={form} onChange={handleChange} />
+          </Grid>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ p: 3, pt: 0 }}>
+        <Button onClick={onClose} disabled={isSubmitting} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          form="admin-product-edit-form"
+          type="submit"
+          variant="contained"
+          startIcon={<SaveRoundedIcon />}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Saving…' : 'Update product'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/client/src/features/products/components/AdminProductForm.jsx
+++ b/client/src/features/products/components/AdminProductForm.jsx
@@ -1,23 +1,8 @@
 import { useState } from 'react';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Grid,
-  TextField,
-} from '@mui/material';
+import { Box, Button, Card, CardContent, CardHeader, Grid } from '@mui/material';
 import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRounded';
-
-const emptyForm = {
-  name: '',
-  description: '',
-  price: '',
-  imageUrl: '',
-  brand: '',
-  stock: '',
-};
+import { ProductFormFields } from './ProductFormFields.jsx';
+import { buildProductPayload, createEmptyProductForm } from './formUtils.js';
 
 /**
  * Renders the product creation form for administrators.
@@ -34,7 +19,7 @@ const emptyForm = {
  * }} props
  */
 export const AdminProductForm = ({ onSubmit, isSubmitting }) => {
-  const [form, setForm] = useState(emptyForm);
+  const [form, setForm] = useState(createEmptyProductForm());
 
   const handleChange = (field) => (event) => {
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
@@ -42,20 +27,13 @@ export const AdminProductForm = ({ onSubmit, isSubmitting }) => {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-    const payload = {
-      name: form.name.trim(),
-      description: form.description.trim(),
-      imageUrl: form.imageUrl.trim(),
-      brand: form.brand.trim(),
-      price: Number.parseFloat(form.price),
-      stock: Number.parseInt(form.stock, 10),
-    };
-    if (Number.isNaN(payload.price) || Number.isNaN(payload.stock)) {
+    const payload = buildProductPayload(form);
+    if (!payload) {
       return;
     }
     const created = await onSubmit(payload);
     if (created) {
-      setForm(emptyForm);
+      setForm(createEmptyProductForm());
     }
   };
 
@@ -68,66 +46,7 @@ export const AdminProductForm = ({ onSubmit, isSubmitting }) => {
       <CardContent>
         <Box component="form" onSubmit={handleSubmit}>
           <Grid container spacing={2.5}>
-            <Grid item xs={12} md={6}>
-              <TextField
-                required
-                fullWidth
-                label="Product name"
-                value={form.name}
-                onChange={handleChange('name')}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <TextField
-                required
-                fullWidth
-                label="Brand"
-                value={form.brand}
-                onChange={handleChange('brand')}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <TextField
-                required
-                fullWidth
-                type="number"
-                inputProps={{ step: '0.01', min: '0' }}
-                label="Price (USD)"
-                value={form.price}
-                onChange={handleChange('price')}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <TextField
-                required
-                fullWidth
-                type="number"
-                inputProps={{ min: '0' }}
-                label="Stock"
-                value={form.stock}
-                onChange={handleChange('stock')}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                required
-                fullWidth
-                multiline
-                minRows={3}
-                label="Description"
-                value={form.description}
-                onChange={handleChange('description')}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                required
-                fullWidth
-                label="Image URL"
-                value={form.imageUrl}
-                onChange={handleChange('imageUrl')}
-              />
-            </Grid>
+            <ProductFormFields form={form} onChange={handleChange} />
             <Grid item xs={12}>
               <Button
                 type="submit"

--- a/client/src/features/products/components/ProductFormFields.jsx
+++ b/client/src/features/products/components/ProductFormFields.jsx
@@ -1,0 +1,68 @@
+import { Grid, TextField } from '@mui/material';
+
+/**
+ * Shared form fields for product management.
+ * @param {{
+ *   form: {
+ *     name: string;
+ *     description: string;
+ *     price: string;
+ *     imageUrl: string;
+ *     brand: string;
+ *     stock: string;
+ *   };
+ *   onChange: (field: string) => (event: import('react').ChangeEvent<HTMLInputElement>) => void;
+ * }} props
+ */
+export const ProductFormFields = ({ form, onChange }) => (
+  <>
+    <Grid item xs={12} md={6}>
+      <TextField required fullWidth label="Product name" value={form.name} onChange={onChange('name')} />
+    </Grid>
+    <Grid item xs={12} md={6}>
+      <TextField required fullWidth label="Brand" value={form.brand} onChange={onChange('brand')} />
+    </Grid>
+    <Grid item xs={12} md={6}>
+      <TextField
+        required
+        fullWidth
+        type="number"
+        inputProps={{ step: '0.01', min: '0' }}
+        label="Price (USD)"
+        value={form.price}
+        onChange={onChange('price')}
+      />
+    </Grid>
+    <Grid item xs={12} md={6}>
+      <TextField
+        required
+        fullWidth
+        type="number"
+        inputProps={{ min: '0' }}
+        label="Stock"
+        value={form.stock}
+        onChange={onChange('stock')}
+      />
+    </Grid>
+    <Grid item xs={12}>
+      <TextField
+        required
+        fullWidth
+        multiline
+        minRows={3}
+        label="Description"
+        value={form.description}
+        onChange={onChange('description')}
+      />
+    </Grid>
+    <Grid item xs={12}>
+      <TextField
+        required
+        fullWidth
+        label="Image URL"
+        value={form.imageUrl}
+        onChange={onChange('imageUrl')}
+      />
+    </Grid>
+  </>
+);

--- a/client/src/features/products/components/formUtils.js
+++ b/client/src/features/products/components/formUtils.js
@@ -1,0 +1,58 @@
+/**
+ * @returns {{
+ *   name: string;
+ *   description: string;
+ *   price: string;
+ *   imageUrl: string;
+ *   brand: string;
+ *   stock: string;
+ * }}
+ */
+export const createEmptyProductForm = () => ({
+  name: '',
+  description: '',
+  price: '',
+  imageUrl: '',
+  brand: '',
+  stock: '',
+});
+
+/**
+ * Maps a product into editable form values.
+ * @param {import('../../../shared/types/products.js').Product | null | undefined} product
+ */
+export const mapProductToFormValues = (product) => ({
+  name: product?.name ?? '',
+  description: product?.description ?? '',
+  price: product?.price != null ? String(product.price) : '',
+  imageUrl: product?.imageUrl ?? '',
+  brand: product?.brand ?? '',
+  stock: product?.stock != null ? String(product.stock) : '',
+});
+
+/**
+ * Builds the payload expected by the API from the editable form values.
+ * @param {{
+ *   name: string;
+ *   description: string;
+ *   price: string;
+ *   imageUrl: string;
+ *   brand: string;
+ *   stock: string;
+ * }} form
+ */
+export const buildProductPayload = (form) => {
+  const price = Number.parseFloat(form.price);
+  const stock = Number.parseInt(form.stock, 10);
+  if (Number.isNaN(price) || Number.isNaN(stock)) {
+    return null;
+  }
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    imageUrl: form.imageUrl.trim(),
+    brand: form.brand.trim(),
+    price,
+    stock,
+  };
+};

--- a/client/src/shared/types/products.js
+++ b/client/src/shared/types/products.js
@@ -1,0 +1,12 @@
+/**
+ * @typedef {Object} Product
+ * @property {number} id
+ * @property {string} name
+ * @property {string} description
+ * @property {string} brand
+ * @property {string} imageUrl
+ * @property {number} stock
+ * @property {number} price
+ * @property {string} [createdAt]
+ * @property {string} [updatedAt]
+ */


### PR DESCRIPTION
## Summary
- add an admin edit dialog so existing products can be updated from the console
- extract reusable product form fields and helpers shared between create and edit flows
- expose a shared product type definition for the client

## Testing
- npm run lint
