### PR TITLE
Add MinIO service to docker compose stack

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,6 +14,7 @@ docker compose up --build
 This command starts the following services:
 - **postgres** – relational database for users, products, and orders.
 - **mongo** – MongoDB instance used for activity logs.
+- **minio** – object storage used for managing product media uploads.
 - **server** – Express API exposed on `http://localhost:4000` with Swagger docs at `/docs`.
 - **client** – React storefront served on `http://localhost:3000`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,17 @@ services:
       - '27017:27017'
     volumes:
       - mongo-data:/data/db
+  minio:
+    image: minio/minio:RELEASE.2024-01-11T07-46-16Z
+    environment:
+      MINIO_ROOT_USER: hemar
+      MINIO_ROOT_PASSWORD: supersecretkey
+    command: server /data --console-address ":9001"
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    volumes:
+      - minio-data:/data
   server:
     build: ./server
     environment:
@@ -27,11 +38,18 @@ services:
       MONGO_URL: mongodb://mongo:27017/hemar
       ADMIN_EMAIL: admin@hemar.test
       ADMIN_PASSWORD: SuperSecure123!
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_PUBLIC_URL: http://localhost:9000
+      MINIO_ACCESS_KEY: hemar
+      MINIO_SECRET_KEY: supersecretkey
+      MINIO_BUCKET: hemar-assets
+      MINIO_REGION: us-east-1
     ports:
       - '4000:4000'
     depends_on:
       - postgres
       - mongo
+      - minio
     command: sh -c "npx prisma migrate deploy && npm run seed && npm run start"
   client:
     build: ./client
@@ -44,3 +62,4 @@ services:
 volumes:
   postgres-data:
   mongo-data:
+  minio-data:


### PR DESCRIPTION
## Summary
- add a MinIO container to the local Docker Compose stack with persisted storage
- inject the MinIO configuration values into the server service environment
- document the MinIO service in the README for local development clarity

## Testing
- not run (docker CLI not available in execution environment)
