### PR TITLE
Normalize product image URLs for public access

### DIFF
--- a/client/src/features/catalog/components/ProductCard.jsx
+++ b/client/src/features/catalog/components/ProductCard.jsx
@@ -68,7 +68,7 @@ export const ProductCard = ({ product, onAddToCart }) => {
 
 ProductCard.propTypes = {
   product: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/server/src/modules/products/products.service.js
+++ b/server/src/modules/products/products.service.js
@@ -1,4 +1,41 @@
 import { prisma } from '../../libs/prisma.js';
+import { env } from '../../config/env.js';
+
+const removeTrailingSlash = (value) => value.replace(/\/+$/, '');
+
+const toAbsolutePath = (value) => {
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  const firstSlashIndex = trimmed.indexOf('/');
+  if (firstSlashIndex > -1) {
+    const potentialHost = trimmed.slice(0, firstSlashIndex);
+    if (potentialHost.includes(':')) {
+      const path = trimmed.slice(firstSlashIndex);
+      return path.startsWith('/') ? path : `/${path}`;
+    }
+  }
+  return `/${trimmed}`;
+};
+
+const ensurePublicImageUrl = (value) => {
+  if (!value) {
+    return value;
+  }
+  try {
+    return new URL(value).href;
+  } catch (error) {
+    const base = removeTrailingSlash(env.storage.publicUrl);
+    const path = toAbsolutePath(value);
+    return path ? `${base}${path}` : base;
+  }
+};
+
+const mapProduct = (product) => (product ? { ...product, imageUrl: ensurePublicImageUrl(product.imageUrl) } : product);
 
 /**
  * Lists products with optional search.
@@ -14,7 +51,8 @@ export const listProducts = async ({ search }) => {
         ],
       }
     : undefined;
-  return prisma.product.findMany({ where, orderBy: { createdAt: 'desc' } });
+  const products = await prisma.product.findMany({ where, orderBy: { createdAt: 'desc' } });
+  return products.map(mapProduct);
 };
 
 /**
@@ -22,27 +60,34 @@ export const listProducts = async ({ search }) => {
  * @param {number} id
  * @returns {Promise<import('../../shared/types/products.js').Product | null>}
  */
-export const getProduct = (id) => prisma.product.findUnique({ where: { id } });
+export const getProduct = async (id) => {
+  const product = await prisma.product.findUnique({ where: { id } });
+  return mapProduct(product);
+};
 
 /**
  * Creates a new product.
  * @param {Omit<import('../../shared/types/products.js').Product, 'id'> & {price: number}} payload
  */
-export const createProduct = (payload) =>
-  prisma.product.create({
+export const createProduct = async (payload) => {
+  const product = await prisma.product.create({
     data: payload,
   });
+  return mapProduct(product);
+};
 
 /**
  * Updates an existing product.
  * @param {number} id
  * @param {Partial<import('../../shared/types/products.js').Product>} payload
  */
-export const updateProduct = (id, payload) =>
-  prisma.product.update({
+export const updateProduct = async (id, payload) => {
+  const product = await prisma.product.update({
     where: { id },
     data: payload,
   });
+  return mapProduct(product);
+};
 
 /**
  * Deletes a product by id.


### PR DESCRIPTION
## Summary
- restore the catalog product card prop type to require numeric product identifiers
- normalize product image URLs on the server so responses always reference the public MinIO host

## Testing
- `npm test -- --watch=false` *(fails: MINIO_ENDPOINT env var required for tests)*
