### PR TITLE
Fix MinIO presigned URLs for browser uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Delivered admin console UI for managing catalog entries and documented seeded admin credentials.
 - Enabled secure product image uploads backed by MinIO presigned URLs and wired the admin console to use them instead of manual
   image links.
+- Fixed presigned upload URLs so browser clients target the publicly reachable MinIO endpoint in local development.
 
 ## 1.0.0 - 2024-05-07
 - Initial release of Hemar Mobile Store platform.

--- a/server/src/integrations/storage/minio.js
+++ b/server/src/integrations/storage/minio.js
@@ -6,15 +6,19 @@ import { env } from '../../config/env.js';
 const normalizeKey = (key) => key.replace(/^\/+/, '');
 const removeTrailingSlash = (value) => value.replace(/\/+$/, '');
 
-export const minioClient = new S3Client({
-  region: env.storage.region,
-  endpoint: env.storage.endpoint,
-  forcePathStyle: true,
-  credentials: {
-    accessKeyId: env.storage.accessKey,
-    secretAccessKey: env.storage.secretKey,
-  },
-});
+const createClient = (endpoint) =>
+  new S3Client({
+    region: env.storage.region,
+    endpoint,
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: env.storage.accessKey,
+      secretAccessKey: env.storage.secretKey,
+    },
+  });
+
+export const minioClient = createClient(env.storage.endpoint);
+const minioPublicClient = createClient(env.storage.publicUrl);
 
 /**
  * Generates a presigned URL for uploading content to MinIO.
@@ -31,7 +35,7 @@ export const createPresignedUploadUrl = async ({ key, contentType, expiresIn = 3
     Key: normalizedKey,
     ContentType: contentType,
   });
-  const uploadUrl = await getSignedUrl(minioClient, command, { expiresIn });
+  const uploadUrl = await getSignedUrl(minioPublicClient, command, { expiresIn });
   return {
     uploadUrl,
     objectKey: normalizedKey,


### PR DESCRIPTION
## Summary
- ensure presigned upload URLs leverage the public MinIO endpoint so the browser can resolve them
- share a single helper for instantiating S3 clients and keep existing internal client for server-side usage
- document the fix in the changelog

## Testing
- not run (not requested)

