### PR TITLE
Allow overriding MinIO upload host for presigned URLs

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -8,6 +8,8 @@ ADMIN_EMAIL=admin@hemar.test
 ADMIN_PASSWORD=SuperSecure123!
 MINIO_ENDPOINT=http://minio:9000
 MINIO_PUBLIC_URL=http://localhost:9000
+# Uncomment to force presigned upload URLs to use a browser-accessible origin
+# MINIO_UPLOAD_URL_OVERRIDE=http://localhost:9000
 MINIO_ACCESS_KEY=hemar
 MINIO_SECRET_KEY=supersecretkey
 MINIO_BUCKET=hemar-assets

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -21,6 +21,7 @@ export const env = {
     secretKey: process.env.MINIO_SECRET_KEY,
     bucket: process.env.MINIO_BUCKET,
     publicUrl: process.env.MINIO_PUBLIC_URL || process.env.MINIO_ENDPOINT,
+    uploadUrlOverride: process.env.MINIO_UPLOAD_URL_OVERRIDE,
   },
 };
 

--- a/server/src/integrations/storage/minio.js
+++ b/server/src/integrations/storage/minio.js
@@ -20,6 +20,22 @@ const createClient = (endpoint) =>
 export const minioClient = createClient(env.storage.endpoint);
 const minioPublicClient = createClient(env.storage.publicUrl);
 
+const applyUploadUrlOverride = (url) => {
+  if (!env.storage.uploadUrlOverride) {
+    return url;
+  }
+
+  try {
+    const overrideUrl = new URL(env.storage.uploadUrlOverride);
+    const signedUrl = new URL(url);
+    signedUrl.protocol = overrideUrl.protocol;
+    signedUrl.host = overrideUrl.host;
+    return signedUrl.toString();
+  } catch (error) {
+    return url;
+  }
+};
+
 /**
  * Generates a presigned URL for uploading content to MinIO.
  * @param {{
@@ -37,7 +53,7 @@ export const createPresignedUploadUrl = async ({ key, contentType, expiresIn = 3
   });
   const uploadUrl = await getSignedUrl(minioPublicClient, command, { expiresIn });
   return {
-    uploadUrl,
+    uploadUrl: applyUploadUrlOverride(uploadUrl),
     objectKey: normalizedKey,
     fileUrl: buildPublicUrl(normalizedKey),
     expiresIn,


### PR DESCRIPTION
## Summary
- allow the storage integration to swap the origin of presigned upload URLs when MINIO_UPLOAD_URL_OVERRIDE is set
- document the new optional environment variable for local development in the server .env example

## Testing
- not run (not requested)
