### PR TITLE
Harden MinIO public URL handling

### DIFF
--- a/client/src/features/products/lib/uploadProductImage.js
+++ b/client/src/features/products/lib/uploadProductImage.js
@@ -1,7 +1,7 @@
 import { api } from '../../../lib/api.js';
 
 /**
- * Uploads a product image using a presigned URL flow.
+ * Uploads a product image via the API and returns its public URL.
  * @param {File} file
  */
 export const uploadProductImage = async (file) => {
@@ -13,25 +13,13 @@ export const uploadProductImage = async (file) => {
     throw new Error('Only image files are supported.');
   }
 
-  const { data } = await api.post('/products/images/upload', {
-    fileName: file.name,
-    contentType: file.type,
-  });
+  const formData = new FormData();
+  formData.append('file', file);
 
-  if (!data?.uploadUrl || !data?.fileUrl) {
+  const { data } = await api.post('/products/images/upload', formData);
+
+  if (!data?.fileUrl) {
     throw new Error('Upload service returned an unexpected response.');
-  }
-
-  const uploadResponse = await fetch(data.uploadUrl, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': file.type,
-    },
-    body: file,
-  });
-
-  if (!uploadResponse.ok) {
-    throw new Error('Failed to upload the image to storage. Please try again.');
   }
 
   return { fileUrl: data.fileUrl };

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,8 +8,6 @@ ADMIN_EMAIL=admin@hemar.test
 ADMIN_PASSWORD=SuperSecure123!
 MINIO_ENDPOINT=http://minio:9000
 MINIO_PUBLIC_URL=http://localhost:9000
-# Uncomment to force presigned upload URLs to use a browser-accessible origin
-# MINIO_UPLOAD_URL_OVERRIDE=http://localhost:9000
 MINIO_ACCESS_KEY=hemar
 MINIO_SECRET_KEY=supersecretkey
 MINIO_BUCKET=hemar-assets

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,8 +8,7 @@
       "name": "hemar-server",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.901.0",
-        "@aws-sdk/s3-request-presigner": "^3.901.0",
+        "@aws-sdk/client-s3": "3.901.0",
         "@prisma/client": "5.7.0",
         "bcrypt": "5.1.1",
         "cors": "2.8.5",
@@ -20,6 +19,7 @@
         "jsonwebtoken": "9.0.2",
         "mongoose": "7.6.0",
         "morgan": "1.10.0",
+        "multer": "^1.4.5-lts.1",
         "swagger-jsdoc": "6.2.8",
         "swagger-ui-express": "5.0.1",
         "winston": "3.10.0"
@@ -797,25 +797,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.901.0.tgz",
-      "integrity": "sha512-G/0G5tL3beETs2zkI0YQuM2SkrAsYJSe2vN2XtouVSN5c9v6EiSvdSsHAqMhLebnSs2suUkq0JO9ZotbXkUfMQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.901.0",
-        "@aws-sdk/types": "3.901.0",
-        "@aws-sdk/util-format-url": "3.901.0",
-        "@smithy/middleware-endpoint": "^4.3.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/smithy-client": "^4.7.0",
-        "@smithy/types": "^4.6.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.901.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.901.0.tgz",
@@ -886,21 +867,6 @@
         "@smithy/types": "^4.6.0",
         "@smithy/url-parser": "^4.2.0",
         "@smithy/util-endpoints": "^3.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.901.0.tgz",
-      "integrity": "sha512-GGUnJKrh3OF1F3YRSWtwPLbN904Fcfxf03gujyq1rcrDRPEkzoZB+2BzNkB27SsU6lAlwNq+4aRlZRVUloPiag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.901.0",
-        "@smithy/querystring-builder": "^4.2.0",
-        "@smithy/types": "^4.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3304,6 +3270,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -3795,8 +3767,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4093,6 +4075,57 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -4140,6 +4173,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -7461,7 +7500,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7661,6 +7699,37 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8298,6 +8367,12 @@
       "engines": {
         "node": ">=16.13"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9060,6 +9135,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -9586,6 +9669,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -9937,6 +10026,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.901.0",
-    "@aws-sdk/s3-request-presigner": "3.901.0",
     "@prisma/client": "5.7.0",
     "bcrypt": "5.1.1",
     "cors": "2.8.5",
@@ -25,6 +24,7 @@
     "jsonwebtoken": "9.0.2",
     "mongoose": "7.6.0",
     "morgan": "1.10.0",
+    "multer": "^1.4.5-lts.1",
     "swagger-jsdoc": "6.2.8",
     "swagger-ui-express": "5.0.1",
     "winston": "3.10.0"

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -21,7 +21,6 @@ export const env = {
     secretKey: process.env.MINIO_SECRET_KEY,
     bucket: process.env.MINIO_BUCKET,
     publicUrl: process.env.MINIO_PUBLIC_URL || process.env.MINIO_ENDPOINT,
-    uploadUrlOverride: process.env.MINIO_UPLOAD_URL_OVERRIDE,
   },
 };
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3,11 +3,13 @@ import { env } from './config/env.js';
 import { prisma } from './libs/prisma.js';
 import { connectMongo } from './libs/mongoose.js';
 import { logger } from './libs/logger.js';
+import { ensurePublicBucketAccess } from './integrations/storage/minio.js';
 
 const start = async () => {
   try {
     await connectMongo();
     await prisma.$connect();
+    await ensurePublicBucketAccess();
     app.listen(env.port, () => {
       logger.info({ message: `Server listening on port ${env.port}` });
     });

--- a/server/src/integrations/storage/utils/urlUtils.js
+++ b/server/src/integrations/storage/utils/urlUtils.js
@@ -1,0 +1,114 @@
+const normalizeKey = (key = '') => String(key).replace(/^\/+/, '');
+const removeTrailingSlash = (value = '') => String(value).replace(/\/+$/, '');
+const ensureLeadingSlash = (value = '') => (String(value).startsWith('/') ? String(value) : `/${String(value)}`);
+
+const ensureBucketPrefixedPath = (path, bucket) => {
+  const withLeadingSlash = ensureLeadingSlash(path || '/');
+
+  if (!bucket) {
+    return withLeadingSlash;
+  }
+
+  if (withLeadingSlash === '/' || withLeadingSlash === '') {
+    return `/${bucket}`;
+  }
+
+  if (withLeadingSlash === `/${bucket}` || withLeadingSlash.startsWith(`/${bucket}/`)) {
+    return withLeadingSlash;
+  }
+
+  return `/${bucket}${withLeadingSlash}`;
+};
+
+const parseUrl = (value) => {
+  try {
+    return new URL(value);
+  } catch (error) {
+    return null;
+  }
+};
+
+const getOrigin = (value) => {
+  const parsed = parseUrl(value);
+  return parsed ? parsed.origin : null;
+};
+
+const toAbsolutePath = (value) => {
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  const firstSlashIndex = trimmed.indexOf('/');
+  if (firstSlashIndex > -1) {
+    const potentialHost = trimmed.slice(0, firstSlashIndex);
+    if (potentialHost.includes(':')) {
+      const path = trimmed.slice(firstSlashIndex);
+      return path.startsWith('/') ? path : `/${path}`;
+    }
+  }
+
+  return `/${trimmed}`;
+};
+
+export const createPublicUrlBuilder = ({ publicUrl, bucket }) => {
+  const base = removeTrailingSlash(publicUrl || '');
+
+  if (!base) {
+    throw new Error('A public storage URL is required to build object URLs.');
+  }
+
+  return (key) => {
+    const normalizedKey = normalizeKey(key);
+    const bucketPath = ensureBucketPrefixedPath(normalizedKey ? `/${normalizedKey}` : '/', bucket);
+    return `${base}${bucketPath}`;
+  };
+};
+
+export const createImageUrlNormalizer = ({ publicUrl, endpoint, bucket }) => {
+  const base = removeTrailingSlash(publicUrl || '');
+
+  if (!base) {
+    throw new Error('A public storage URL is required to normalize image URLs.');
+  }
+
+  const endpointOrigin = getOrigin(endpoint);
+
+  return (value) => {
+    if (!value) {
+      return value;
+    }
+
+    const parsed = parseUrl(value);
+
+    if (!parsed) {
+      const absolutePath = toAbsolutePath(value);
+      if (!absolutePath) {
+        return base;
+      }
+      const bucketPath = ensureBucketPrefixedPath(absolutePath, bucket);
+      return `${base}${bucketPath}`;
+    }
+
+    if (endpointOrigin && parsed.origin === endpointOrigin) {
+      const bucketPath = ensureBucketPrefixedPath(parsed.pathname, bucket);
+      return `${base}${bucketPath}${parsed.search}${parsed.hash}`;
+    }
+
+    return parsed.href;
+  };
+};
+
+export const __private = {
+  normalizeKey,
+  removeTrailingSlash,
+  ensureLeadingSlash,
+  ensureBucketPrefixedPath,
+  parseUrl,
+  getOrigin,
+  toAbsolutePath,
+};

--- a/server/src/integrations/storage/utils/urlUtils.test.js
+++ b/server/src/integrations/storage/utils/urlUtils.test.js
@@ -1,0 +1,55 @@
+import { createImageUrlNormalizer, createPublicUrlBuilder } from './urlUtils.js';
+
+const config = {
+  publicUrl: 'http://localhost:9000/',
+  endpoint: 'http://minio:9000',
+  bucket: 'hemar-assets',
+};
+
+describe('storage url utils', () => {
+  describe('createPublicUrlBuilder', () => {
+    it('builds a public URL with the bucket prefix for object keys', () => {
+      const buildPublicUrl = createPublicUrlBuilder(config);
+      expect(buildPublicUrl('products/phone.jpg')).toBe('http://localhost:9000/hemar-assets/products/phone.jpg');
+    });
+
+    it('handles keys with leading slashes without duplicating them', () => {
+      const buildPublicUrl = createPublicUrlBuilder(config);
+      expect(buildPublicUrl('/products/phone.jpg')).toBe('http://localhost:9000/hemar-assets/products/phone.jpg');
+    });
+
+    it('falls back to the bucket root when key is missing', () => {
+      const buildPublicUrl = createPublicUrlBuilder(config);
+      expect(buildPublicUrl('')).toBe('http://localhost:9000/hemar-assets');
+    });
+  });
+
+  describe('createImageUrlNormalizer', () => {
+    const normalize = createImageUrlNormalizer(config);
+
+    it('passes through already public URLs', () => {
+      const url = 'https://cdn.example.com/assets/products/phone.jpg';
+      expect(normalize(url)).toBe(url);
+    });
+
+    it('rewrites internal endpoint URLs to the public base', () => {
+      const url = 'http://minio:9000/hemar-assets/products/phone.jpg';
+      expect(normalize(url)).toBe('http://localhost:9000/hemar-assets/products/phone.jpg');
+    });
+
+    it('normalizes relative paths by adding the bucket prefix', () => {
+      expect(normalize('products/phone.jpg')).toBe('http://localhost:9000/hemar-assets/products/phone.jpg');
+    });
+
+    it('keeps relative paths that already include the bucket prefix intact', () => {
+      expect(normalize('/hemar-assets/products/phone.jpg')).toBe(
+        'http://localhost:9000/hemar-assets/products/phone.jpg',
+      );
+    });
+
+    it('returns the public base when value is falsy', () => {
+      expect(normalize('')).toBe('');
+      expect(normalize(null)).toBe(null);
+    });
+  });
+});

--- a/server/src/middlewares/upload.js
+++ b/server/src/middlewares/upload.js
@@ -1,0 +1,12 @@
+import multer from 'multer';
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB limit for product images
+
+const storage = multer.memoryStorage();
+
+export const upload = multer({
+  storage,
+  limits: {
+    fileSize: MAX_FILE_SIZE_BYTES,
+  },
+});

--- a/server/src/modules/products/products.controller.js
+++ b/server/src/modules/products/products.controller.js
@@ -6,7 +6,7 @@ import {
   deleteProduct,
 } from './products.service.js';
 import { recordActivity } from '../activities/activities.service.js';
-import { createProductImageUpload } from './productImages.service.js';
+import { uploadProductImage } from './productImages.service.js';
 
 /**
  * @param {import('express').Request} req
@@ -48,13 +48,20 @@ export const store = async (req, res, next) => {
   }
 };
 
-export const requestImageUpload = async (req, res, next) => {
+export const uploadImage = async (req, res, next) => {
   try {
-    const { uploadUrl, fileUrl, expiresIn } = await createProductImageUpload({
-      fileName: req.body?.fileName,
-      contentType: req.body?.contentType,
+    if (!req.file) {
+      const error = new Error('An image file is required for upload.');
+      error.status = 400;
+      throw error;
+    }
+
+    const { fileUrl } = await uploadProductImage({
+      fileName: req.file.originalname,
+      contentType: req.file.mimetype,
+      buffer: req.file.buffer,
     });
-    res.status(201).json({ uploadUrl, fileUrl, expiresIn });
+    res.status(201).json({ fileUrl });
   } catch (error) {
     next(error);
   }

--- a/server/src/modules/products/products.routes.js
+++ b/server/src/modules/products/products.routes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { authenticate, authorize } from '../../middlewares/auth.js';
-import { index, show, store, update, destroy, requestImageUpload } from './products.controller.js';
+import { index, show, store, update, destroy, uploadImage } from './products.controller.js';
+import { upload } from '../../middlewares/upload.js';
 
 const router = Router();
 
@@ -27,29 +28,30 @@ router.get('/:id', show);
  * /api/products/images/upload:
  *   post:
  *     tags: [Products]
- *     summary: Generate a presigned URL for uploading a product image
+ *     summary: Upload a product image directly to storage
  *     requestBody:
  *       required: true
  *       content:
- *         application/json:
+ *         multipart/form-data:
  *           schema:
  *             type: object
- *             required:
- *               - fileName
- *               - contentType
  *             properties:
- *               fileName:
+ *               file:
  *                 type: string
- *               contentType:
- *                 type: string
- *                 example: image/jpeg
+ *                 format: binary
  *     responses:
  *       201:
- *         description: Presigned upload URL generated
+ *         description: Image uploaded successfully
  *       400:
  *         description: Validation error
  */
-router.post('/images/upload', authenticate, authorize('ADMIN'), requestImageUpload);
+router.post(
+  '/images/upload',
+  authenticate,
+  authorize('ADMIN'),
+  upload.single('file'),
+  uploadImage,
+);
 
 router.post('/', authenticate, authorize('ADMIN'), store);
 router.put('/:id', authenticate, authorize('ADMIN'), update);


### PR DESCRIPTION
## Summary
- rely on Axios to set multipart boundaries for admin image uploads so MinIO receives the binary payload
- centralize public MinIO URL building/normalization and ensure the bucket exists before applying the read policy
- add targeted tests for the new storage URL utilities and remove the unused presigner dependency/config hint

## Testing
- npm run lint (server)
- npm run lint (client)
- npm test -- urlUtils

------
https://chatgpt.com/codex/tasks/task_e_68e3ca9e285c8333abca0fa0616d7952